### PR TITLE
docs: Fix @mailty-to/core installation package name

### DIFF
--- a/packages/core/readme.md
+++ b/packages/core/readme.md
@@ -14,7 +14,7 @@
 ## Installation
 
 ```bash
-pnpm add @maily.to/core
+pnpm add @maily-to/core
 
 # for types
 pnpm add -D @tiptap/core


### PR DESCRIPTION
The installation instructions previously used `@maily.to` instead of `@maily-to` scope, which resulted in not-found errors when attempting to install