### PR TITLE
feat: Remove 5-item limit from variable suggestions and add scrollable UI

### DIFF
--- a/packages/core/src/editor/nodes/variable/variable-suggestions.tsx
+++ b/packages/core/src/editor/nodes/variable/variable-suggestions.tsx
@@ -3,11 +3,19 @@ import { cn } from '@/editor/utils/classname';
 import { ReactRenderer } from '@tiptap/react';
 import { SuggestionOptions } from '@tiptap/suggestion';
 import { ArrowDown, ArrowUp, Braces, CornerDownLeft } from 'lucide-react';
-import { forwardRef, useEffect, useImperativeHandle, useState } from 'react';
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useState,
+  useRef,
+} from 'react';
 import tippy, { GetReferenceClientRect } from 'tippy.js';
 
 export const VariableList = forwardRef((props: any, ref) => {
   const [selectedIndex, setSelectedIndex] = useState(0);
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const itemRefs = useRef<(HTMLButtonElement | null)[]>([]);
 
   const selectItem = (index: number) => {
     const item = props.items[index];
@@ -18,13 +26,42 @@ export const VariableList = forwardRef((props: any, ref) => {
     props.command({ id: item });
   };
 
+  const scrollSelectedIntoView = (index: number) => {
+    const container = scrollContainerRef.current;
+    const selectedItem = itemRefs.current[index];
+
+    if (!container || !selectedItem) return;
+
+    const containerRect = container.getBoundingClientRect();
+    const itemRect = selectedItem.getBoundingClientRect();
+
+    if (itemRect.bottom > containerRect.bottom) {
+      // Scroll down if item is below viewport
+      container.scrollTop += itemRect.bottom - containerRect.bottom;
+    } else if (itemRect.top < containerRect.top) {
+      // Scroll up if item is above viewport
+      container.scrollTop += itemRect.top - containerRect.top;
+    }
+  };
+
   useEffect(() => {
     setSelectedIndex(0);
+    // Reset scroll position when items change
+    if (scrollContainerRef.current) {
+      scrollContainerRef.current.scrollTop = 0;
+    }
+    // Reset item refs array
+    itemRefs.current = props.items.map(() => null);
   }, [props.items]);
+
+  useEffect(() => {
+    scrollSelectedIntoView(selectedIndex);
+  }, [selectedIndex]);
 
   useImperativeHandle(ref, () => ({
     onKeyDown: ({ event }: { event: KeyboardEvent }) => {
       if (event.key === 'ArrowUp') {
+        event.preventDefault();
         setSelectedIndex(
           (selectedIndex + props.items.length - 1) % props.items.length
         );
@@ -32,6 +69,7 @@ export const VariableList = forwardRef((props: any, ref) => {
       }
 
       if (event.key === 'ArrowDown') {
+        event.preventDefault();
         setSelectedIndex((selectedIndex + 1) % props.items.length);
         return true;
       }
@@ -46,7 +84,7 @@ export const VariableList = forwardRef((props: any, ref) => {
   }));
 
   return (
-    <div className="mly-z-50 mly-h-auto mly-min-w-[240px] mly-overflow-hidden mly-rounded-lg mly-border mly-border-gray-200 mly-bg-white mly-shadow-md mly-transition-all">
+    <div className="mly-z-50 mly-w-64 mly-rounded-lg mly-border mly-border-gray-200 mly-bg-white mly-shadow-md mly-transition-all">
       <div className="mly-flex mly-items-center mly-justify-between mly-gap-2 mly-border-b mly-border-gray-200 mly-bg-soft-gray/40 mly-px-1 mly-py-1.5 mly-text-gray-500">
         <span className="mly-text-xs mly-uppercase">Variables</span>
         <VariableIcon>
@@ -54,26 +92,32 @@ export const VariableList = forwardRef((props: any, ref) => {
         </VariableIcon>
       </div>
 
-      <div className="mly-flex mly-flex-col mly-gap-0.5 mly-p-1">
-        {props?.items?.length ? (
-          props?.items?.map((item: string, index: number) => (
-            <button
-              key={index}
-              onClick={() => selectItem(index)}
-              className={cn(
-                'mly-flex mly-w-full mly-items-center mly-gap-2 mly-rounded-md mly-px-2 mly-py-1 mly-text-left mly-font-mono mly-text-sm mly-text-gray-900 hover:mly-bg-soft-gray',
-                index === selectedIndex ? 'mly-bg-soft-gray' : 'mly-bg-white'
-              )}
-            >
-              <Braces className="mly-size-3 mly-stroke-[2.5] mly-text-rose-600" />
-              {item}
-            </button>
-          ))
-        ) : (
-          <div className="mly-flex mly-w-full mly-items-center mly-gap-2 mly-rounded-md mly-px-2 mly-py-1 mly-text-left mly-font-mono mly-text-sm mly-text-gray-900 hover:mly-bg-soft-gray">
-            No result
-          </div>
-        )}
+      <div
+        ref={scrollContainerRef}
+        className="mly-scrollbar-thin mly-scrollbar-track-transparent mly-scrollbar-thumb-gray-200 mly-max-h-64 mly-overflow-y-auto"
+      >
+        <div className="mly-flex mly-flex-col mly-gap-0.5 mly-p-1">
+          {props?.items?.length ? (
+            props?.items?.map((item: string, index: number) => (
+              <button
+                key={index}
+                ref={(el) => (itemRefs.current[index] = el)}
+                onClick={() => selectItem(index)}
+                className={cn(
+                  'mly-flex mly-w-full mly-items-center mly-gap-2 mly-rounded-md mly-px-2 mly-py-1 mly-text-left mly-font-mono mly-text-sm mly-text-gray-900 hover:mly-bg-soft-gray',
+                  index === selectedIndex ? 'mly-bg-soft-gray' : 'mly-bg-white'
+                )}
+              >
+                <Braces className="mly-size-3 mly-stroke-[2.5] mly-text-rose-600" />
+                {item}
+              </button>
+            ))
+          ) : (
+            <div className="mly-flex mly-w-full mly-items-center mly-gap-2 mly-rounded-md mly-px-2 mly-py-1 mly-text-left mly-font-mono mly-text-sm mly-text-gray-900">
+              No result
+            </div>
+          )}
+        </div>
       </div>
 
       <div className="mly-flex mly-items-center mly-justify-between mly-gap-2 mly-border-t mly-border-gray-200 mly-px-1 mly-py-1.5 mly-text-gray-500">
@@ -84,7 +128,6 @@ export const VariableList = forwardRef((props: any, ref) => {
           <VariableIcon>
             <ArrowUp className="mly-size-3 mly-stroke-[2.5]" />
           </VariableIcon>
-
           <span className="mly-text-xs mly-text-gray-500">Navigate</span>
         </div>
         <VariableIcon>
@@ -94,6 +137,8 @@ export const VariableList = forwardRef((props: any, ref) => {
     </div>
   );
 });
+
+VariableList.displayName = 'VariableList';
 
 type VariableIconProps = {
   className?: string;
@@ -142,7 +187,7 @@ export function getVariableSuggestions(
         combinedKeys.push(query);
       }
 
-      return combinedKeys.slice(0, 5);
+      return combinedKeys;
     },
 
     render: () => {
@@ -186,7 +231,6 @@ export function getVariableSuggestions(
         onKeyDown(props) {
           if (props.event.key === 'Escape') {
             popup?.[0].hide();
-
             return true;
           }
 

--- a/packages/core/src/editor/nodes/variable/variable-suggestions.tsx
+++ b/packages/core/src/editor/nodes/variable/variable-suggestions.tsx
@@ -13,6 +13,8 @@ import {
 import tippy, { GetReferenceClientRect } from 'tippy.js';
 
 export const VariableList = forwardRef((props: any, ref) => {
+  const { items = [] } = props;
+
   const [selectedIndex, setSelectedIndex] = useState(0);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const itemRefs = useRef<(HTMLButtonElement | null)[]>([]);
@@ -30,17 +32,20 @@ export const VariableList = forwardRef((props: any, ref) => {
     const container = scrollContainerRef.current;
     const selectedItem = itemRefs.current[index];
 
-    if (!container || !selectedItem) return;
+    if (!container || !selectedItem) {
+      return;
+    }
 
     const containerRect = container.getBoundingClientRect();
     const itemRect = selectedItem.getBoundingClientRect();
 
+    const padding = 4;
     if (itemRect.bottom > containerRect.bottom) {
       // Scroll down if item is below viewport
-      container.scrollTop += itemRect.bottom - containerRect.bottom;
+      container.scrollTop += itemRect.bottom - containerRect.bottom + padding;
     } else if (itemRect.top < containerRect.top) {
       // Scroll up if item is above viewport
-      container.scrollTop += itemRect.top - containerRect.top;
+      container.scrollTop += itemRect.top - containerRect.top - padding;
     }
   };
 
@@ -62,15 +67,13 @@ export const VariableList = forwardRef((props: any, ref) => {
     onKeyDown: ({ event }: { event: KeyboardEvent }) => {
       if (event.key === 'ArrowUp') {
         event.preventDefault();
-        setSelectedIndex(
-          (selectedIndex + props.items.length - 1) % props.items.length
-        );
+        setSelectedIndex((selectedIndex + items.length - 1) % items.length);
         return true;
       }
 
       if (event.key === 'ArrowDown') {
         event.preventDefault();
-        setSelectedIndex((selectedIndex + 1) % props.items.length);
+        setSelectedIndex((selectedIndex + 1) % items.length);
         return true;
       }
 
@@ -94,11 +97,11 @@ export const VariableList = forwardRef((props: any, ref) => {
 
       <div
         ref={scrollContainerRef}
-        className="mly-scrollbar-thin mly-scrollbar-track-transparent mly-scrollbar-thumb-gray-200 mly-max-h-64 mly-overflow-y-auto"
+        className="mly-max-h-52 mly-overflow-y-auto mly-scrollbar-thin mly-scrollbar-track-transparent mly-scrollbar-thumb-gray-200"
       >
         <div className="mly-flex mly-flex-col mly-gap-0.5 mly-p-1">
-          {props?.items?.length ? (
-            props?.items?.map((item: string, index: number) => (
+          {items?.length ? (
+            items?.map((item: string, index: number) => (
               <button
                 key={index}
                 ref={(el) => (itemRefs.current[index] = el)}

--- a/packages/core/tailwind.config.ts
+++ b/packages/core/tailwind.config.ts
@@ -1,8 +1,10 @@
-// tailwind config is required for editor support
 import type { Config } from 'tailwindcss';
 import sharedConfig from 'tailwind-config/tailwind.config';
 
-const config: Pick<Config, 'prefix' | 'presets' | 'corePlugins' | 'theme'> = {
+const config: Pick<
+  Config,
+  'prefix' | 'presets' | 'corePlugins' | 'theme' | 'plugins'
+> = {
   prefix: 'mly-',
   corePlugins: {
     // Disable preflight to avoid Tailwind overriding the styles of the editor.

--- a/packages/tailwind-config/package.json
+++ b/packages/tailwind-config/package.json
@@ -9,6 +9,7 @@
     "postcss": "^8.4.47",
     "prettier": "^3.3.3",
     "prettier-plugin-tailwindcss": "^0.6.8",
+    "tailwind-scrollbar": "^3.1.0",
     "tailwindcss": "^3.4.14",
     "tailwindcss-animate": "^1.0.7"
   }

--- a/packages/tailwind-config/tailwind.config.ts
+++ b/packages/tailwind-config/tailwind.config.ts
@@ -13,7 +13,11 @@ const config: Config = {
   theme: {
     extend: {},
   },
-  plugins: [require('@tailwindcss/typography'), require('tailwindcss-animate')],
+  plugins: [
+    require('@tailwindcss/typography'),
+    require('tailwindcss-animate'),
+    require('tailwind-scrollbar'),
+  ],
 };
 
 export default config;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -344,6 +344,9 @@ importers:
       prettier-plugin-tailwindcss:
         specifier: ^0.6.8
         version: 0.6.8(prettier@3.3.3)
+      tailwind-scrollbar:
+        specifier: ^3.1.0
+        version: 3.1.0(tailwindcss@3.4.14)
       tailwindcss:
         specifier: ^3.4.14
         version: 3.4.14
@@ -3166,6 +3169,12 @@ packages:
 
   tailwind-merge@2.5.4:
     resolution: {integrity: sha512-0q8cfZHMu9nuYP/b5Shb7Y7Sh1B7Nnl5GqNr1U+n2p6+mybvRtayrQ+0042Z5byvTA8ihjlP8Odo8/VnHbZu4Q==}
+
+  tailwind-scrollbar@3.1.0:
+    resolution: {integrity: sha512-pmrtDIZeHyu2idTejfV59SbaJyvp1VRjYxAjZBH0jnyrPRo6HL1kD5Glz8VPagasqr6oAx6M05+Tuw429Z8jxg==}
+    engines: {node: '>=12.13.0'}
+    peerDependencies:
+      tailwindcss: 3.x
 
   tailwindcss-animate@1.0.7:
     resolution: {integrity: sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==}
@@ -6403,6 +6412,10 @@ snapshots:
   supports-preserve-symlinks-flag@1.0.0: {}
 
   tailwind-merge@2.5.4: {}
+
+  tailwind-scrollbar@3.1.0(tailwindcss@3.4.14):
+    dependencies:
+      tailwindcss: 3.4.14
 
   tailwindcss-animate@1.0.7(tailwindcss@3.4.14):
     dependencies:


### PR DESCRIPTION
## Problem
Currently, the variable suggestions dropdown is limited to showing only 5 variables at a time. This restriction prevents users from seeing all available variables when the suggestions list opens, leading to a suboptimal user experience where users can't get a complete overview of their options.

## Solution
This PR enhances the variable suggestions UI by:
- Removing the artificial limit of 5 variables
- Adding a scrollable container with a max height of 16rem (64 tailwind units)

## Changes
- Removed `.slice(0, 5)` from the suggestions filter
- Added a scrollable container with custom scrollbar styling
- Implemented `scrollSelectedIntoView` function to handle auto-scrolling
- Added refs to track suggestion items and scroll container
- Reset scroll position when suggestion items change

## Screenshots
<img width="615" alt="image" src="https://github.com/user-attachments/assets/255c8811-4984-4504-aa74-d685caf91404">
