### PR TITLE
feat: allow using custom variable list component

### DIFF
--- a/packages/core/readme.md
+++ b/packages/core/readme.md
@@ -144,7 +144,8 @@ import { MailyKit, VariableExtension, getVariableSuggestions } from '@maily-to/c
     }).configure({
       suggestions: getVariableSuggestions(
         variables,
-        variableTriggerCharacter
+        variableTriggerCharacter,
+        variableListComponent, // optional custom component for variable list
       ),
     }),
   ]}

--- a/packages/core/src/editor/nodes/variable/variable-suggestions.tsx
+++ b/packages/core/src/editor/nodes/variable/variable-suggestions.tsx
@@ -7,12 +7,11 @@ import {
 import { processVariables } from '@/editor/utils/variable';
 import { ReactRenderer } from '@tiptap/react';
 import { SuggestionOptions } from '@tiptap/suggestion';
-import { forwardRef, useImperativeHandle, useState } from 'react';
+import { useRef, forwardRef, useImperativeHandle, ComponentType } from 'react';
 import tippy, { GetReferenceClientRect } from 'tippy.js';
 import { VariablePopover, VariablePopoverRef } from './variable-popover';
-import { useRef } from 'react';
 
-type VariableListProps = {
+export type VariableListProps = {
   command: (params: { id: string; required: boolean }) => void;
   items: VariableType[];
 };
@@ -68,7 +67,8 @@ VariableList.displayName = 'VariableList';
 
 export function getVariableSuggestions(
   variables: Variables = DEFAULT_VARIABLES,
-  char: string = DEFAULT_VARIABLE_TRIGGER_CHAR
+  char: string = DEFAULT_VARIABLE_TRIGGER_CHAR,
+  variableListComponent: ComponentType<VariableListProps> = VariableList,
 ): Omit<SuggestionOptions, 'editor'> {
   return {
     char,
@@ -86,7 +86,7 @@ export function getVariableSuggestions(
 
       return {
         onStart: (props) => {
-          component = new ReactRenderer(VariableList, {
+          component = new ReactRenderer(variableListComponent, {
             props,
             editor: props.editor,
           });


### PR DESCRIPTION
The changes in this PR allow using the custom variable list component for the suggestions when extending the `VariableExtension`.

![Screenshot 2025-01-30 at 13 56 00](https://github.com/user-attachments/assets/254395fb-ff08-4ae3-9dd5-34b9364a75ab)
