### PR TITLE
fix: image size issues

### DIFF
--- a/packages/core/src/editor/components/image-menu/image-bubble-menu.tsx
+++ b/packages/core/src/editor/components/image-menu/image-bubble-menu.tsx
@@ -139,21 +139,21 @@ export function ImageBubbleMenu(props: EditorBubbleMenuProps) {
             <div className="mly-flex mly-space-x-0.5">
               <ImageSize
                 dimension="width"
-                value={state?.width ?? 0}
+                value={state?.width ?? ''}
                 onValueChange={(value) => {
                   editor
                     ?.chain()
-                    .updateAttributes('image', { width: value })
+                    .updateAttributes('image', { width: value || null })
                     .run();
                 }}
               />
               <ImageSize
                 dimension="height"
-                value={state?.height ?? 0}
+                value={state?.height ?? ''}
                 onValueChange={(value) => {
                   editor
                     ?.chain()
-                    .updateAttributes('image', { height: value })
+                    .updateAttributes('image', { height: value || null })
                     .run();
                 }}
               />

--- a/packages/core/src/editor/components/image-menu/use-image-state.tsx
+++ b/packages/core/src/editor/components/image-menu/use-image-state.tsx
@@ -7,8 +7,8 @@ export const useImageState = (editor: Editor) => {
     editor,
     selector: ({ editor }) => {
       return {
-        width: editor.getAttributes('image').width,
-        height: editor.getAttributes('image').height,
+        width: editor.getAttributes('image').width as string,
+        height: editor.getAttributes('image').height as string,
         isImageActive: editor.isActive('image'),
         isLogoActive: editor.isActive('logo'),
         alignment:

--- a/packages/core/src/editor/components/inline-image-menu/inline-image-bubble-menu.tsx
+++ b/packages/core/src/editor/components/inline-image-menu/inline-image-bubble-menu.tsx
@@ -7,6 +7,10 @@ import { useInlineImageState } from './use-inline-image-state';
 import { LinkInputPopover } from '../ui/link-input-popover';
 import { ImageDownIcon } from 'lucide-react';
 import { isTextSelected } from '@/editor/utils/is-text-selected';
+import {
+  DEFAULT_INLINE_IMAGE_HEIGHT,
+  DEFAULT_INLINE_IMAGE_WIDTH,
+} from '@/editor/nodes/inline-image/inline-image';
 
 export function InlineImageBubbleMenu(props: EditorBubbleMenuProps) {
   const { editor, appendTo } = props;
@@ -83,8 +87,8 @@ export function InlineImageBubbleMenu(props: EditorBubbleMenuProps) {
               editor
                 ?.chain()
                 .updateAttributes('inlineImage', {
-                  width: value,
-                  height: value,
+                  width: value || DEFAULT_INLINE_IMAGE_WIDTH,
+                  height: value || DEFAULT_INLINE_IMAGE_HEIGHT,
                 })
                 .run();
             }}

--- a/packages/core/src/editor/nodes/image/image-view.tsx
+++ b/packages/core/src/editor/nodes/image/image-view.tsx
@@ -94,6 +94,7 @@ export function ImageView(props: NodeViewProps) {
   }
 
   let { alignment = 'center', width, height, src } = node.attrs || {};
+
   const {
     externalLink,
     isExternalLinkVariable,
@@ -120,6 +121,7 @@ export function ImageView(props: NodeViewProps) {
       // update the dimensions to ensure that the image is not stretched
       const { naturalWidth, naturalHeight } = img;
       const wrapper = wrapperRef?.current;
+
       if (!wrapper || width !== 'auto' || !naturalWidth) {
         return;
       }
@@ -155,8 +157,8 @@ export function ImageView(props: NodeViewProps) {
       style={{
         ...(hasImageSrc && status === 'loaded'
           ? {
-              width: `${width}px`,
-              height: `${height}px`,
+              width: width ? `${width}px` : undefined,
+              height: height ? `${height}px` : undefined,
               ...resizingStyle,
             }
           : {}),

--- a/packages/core/src/editor/nodes/image/image.ts
+++ b/packages/core/src/editor/nodes/image/image.ts
@@ -9,19 +9,25 @@ export const ImageExtension = TiptapImage.extend({
       ...this.parent?.(),
       width: {
         default: 'auto',
-        parseHTML: (element) => {
-          const width = element.style.width;
-          return width ? { width } : null;
-        },
-        renderHTML: ({ width }) => ({ style: `width: ${width}` }),
+        parseHTML: (element) =>
+          element.getAttribute('width') ||
+          (element.style?.width || element.style?.inlineSize)?.replace(
+            'px',
+            ''
+          ) ||
+          null,
+        renderHTML: ({ width }) => ({ width }),
       },
       height: {
         default: 'auto',
-        parseHTML: (element) => {
-          const height = element.style.height;
-          return height ? { height } : null;
-        },
-        renderHTML: ({ height }) => ({ style: `height: ${height}` }),
+        parseHTML: (element) =>
+          element.getAttribute('height') ||
+          (element.style?.height || element.style?.blockSize)?.replace(
+            'px',
+            ''
+          ) ||
+          null,
+        renderHTML: ({ height }) => ({ height }),
       },
       alignment: {
         default: 'center',


### PR DESCRIPTION
Fixed several issues related to image size:

**Image**
* When copying content from one editor to another or copying rich text from elsewhere into the editor, images lose their styled size. Fixed the cause in `parseHTML` and `renderHTML` (Setting a numeric value without unit like 'px' for width/height in style is invalid, causing `element.style.width` to return nothing.)
* When setting the width/height of an image block and then clearing the input value, the image size remains unchanged on that axis. Change it to auto-fit on that axis.
  
**InlineImage**
* When setting the size, clearing the input value, the input value reverts to 20, but the image style lacks width and height. Change it to reset to the default value of 20 when the input value is cleared.