### PR TITLE
fix: color picker input styling

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": "explicit"
+    "source.fixAll.eslint": "explicit",
+    "source.organizeImports": "never"
   }
 }

--- a/packages/core/src/editor/components/ui/color-picker.tsx
+++ b/packages/core/src/editor/components/ui/color-picker.tsx
@@ -104,7 +104,7 @@ export function ColorPicker(props: ColorPickerProps) {
             alpha={true}
             color={color}
             onChange={handleColorChange}
-            className="mly-mt-4 mly-w-full mly-min-w-0 mly-rounded-lg mly-border mly-border-gray-200 mly-px-2 mly-py-1.5 mly-text-sm mly-uppercase focus-visible:mly-border-gray-400 focus-visible:mly-outline-none"
+            className="mly-mt-4 mly-w-full mly-min-w-0 mly-rounded-lg mly-border mly-border-gray-200 mly-bg-white mly-px-2 mly-py-1.5 mly-text-sm mly-uppercase focus-visible:mly-border-gray-400 focus-visible:mly-outline-none"
             prefixed
           />
 


### PR DESCRIPTION
## Input Dark Mode Bug

Enforce the color of the input:

![CleanShot 2025-03-07 at 12 08 56@2x](https://github.com/user-attachments/assets/02971519-f482-40cc-bdca-23be4850d448)

## Settings

Add settings to avoid reorganizing imports every time to prevent a big diff. Consider adding import sorting at the ESLint level? 

Best