### PR TITLE
feat: show slash cmd preview on hover

### DIFF
--- a/packages/core/src/editor/extensions/slash-command/slash-command-view.tsx
+++ b/packages/core/src/editor/extensions/slash-command/slash-command-view.tsx
@@ -199,7 +199,6 @@ const CommandList = forwardRef(function CommandList(
                     value = renderFunctionValue!;
                   }
 
-                  // const shouldOpenTooltip = !!item?.preview && isActive;
                   const shouldOpenTooltip =
                     !!item?.preview &&
                     (isActive ||

--- a/packages/core/src/editor/extensions/slash-command/slash-command-view.tsx
+++ b/packages/core/src/editor/extensions/slash-command/slash-command-view.tsx
@@ -40,6 +40,10 @@ const CommandList = forwardRef(function CommandList(
 
   const [selectedGroupIndex, setSelectedGroupIndex] = useState(0);
   const [selectedCommandIndex, setSelectedCommandIndex] = useState(0);
+  const [hoveredIndex, setHoveredIndex] = useState<{
+    group: number;
+    command: number;
+  } | null>(null);
 
   const selectItem = useCallback(
     (groupIndex: number, commandIndex: number) => {
@@ -195,7 +199,12 @@ const CommandList = forwardRef(function CommandList(
                     value = renderFunctionValue!;
                   }
 
-                  const shouldOpenTooltip = !!item?.preview && isActive;
+                  // const shouldOpenTooltip = !!item?.preview && isActive;
+                  const shouldOpenTooltip =
+                    !!item?.preview &&
+                    (isActive ||
+                      (hoveredIndex?.group === groupIndex &&
+                        hoveredIndex?.command === commandIndex));
 
                   return (
                     <Tooltip open={shouldOpenTooltip} key={commandIndex}>
@@ -208,6 +217,13 @@ const CommandList = forwardRef(function CommandList(
                               : 'mly-bg-transparent'
                           )}
                           onClick={() => selectItem(groupIndex, commandIndex)}
+                          onMouseEnter={() =>
+                            setHoveredIndex({
+                              group: groupIndex,
+                              command: commandIndex,
+                            })
+                          }
+                          onMouseLeave={() => setHoveredIndex(null)}
                           type="button"
                           ref={isActive ? activeCommandRef : null}
                         >


### PR DESCRIPTION
Show slash command preview on hover as well, since a lot of users are using mouse to select the block instead of arrows.

https://github.com/user-attachments/assets/fd0a3642-886e-4ede-b2eb-c94e8d79e45c

