### PR TITLE
feat(html-block): add style tag support & fix style leaks

### DIFF
--- a/packages/core/src/editor/nodes/html/html-view.tsx
+++ b/packages/core/src/editor/nodes/html/html-view.tsx
@@ -60,10 +60,19 @@ export function HTMLCodeBlockView(props: NodeViewProps) {
             if (!node || node?.shadowRoot) {
               return;
             }
-            // shadow DOM to prevent styles from leaking
             const shadow = node.attachShadow({ mode: 'open' });
-            const htmlWithStyles = `<style>blockquote,h1,h2,h3,img,li,ol,p,ul{margin-top:0;margin-bottom:0}</style>${html}`;
-            shadow.innerHTML = htmlWithStyles;
+            const sheet = new CSSStyleSheet();
+            sheet.replaceSync(`
+              * { all: unset; }
+              blockquote, h1, h2, h3, img, li, ol, p, ul {
+                margin-top: 0;
+                margin-bottom: 0;
+              }
+            `);
+            shadow.adoptedStyleSheets = [sheet];
+            const container = document.createElement('div');
+            container.innerHTML = html;
+            shadow.appendChild(container);
           }}
           contentEditable={false}
           onClick={() => {

--- a/packages/core/src/editor/nodes/html/html-view.tsx
+++ b/packages/core/src/editor/nodes/html/html-view.tsx
@@ -63,7 +63,7 @@ export function HTMLCodeBlockView(props: NodeViewProps) {
             const shadow = node.attachShadow({ mode: 'open' });
             const sheet = new CSSStyleSheet();
             sheet.replaceSync(`
-              * { all: unset; }
+              * { font-family: 'Inter', sans-serif; }
               blockquote, h1, h2, h3, img, li, ol, p, ul {
                 margin-top: 0;
                 margin-bottom: 0;

--- a/packages/core/src/editor/nodes/html/html-view.tsx
+++ b/packages/core/src/editor/nodes/html/html-view.tsx
@@ -29,14 +29,8 @@ export function HTMLCodeBlockView(props: NodeViewProps) {
 
     const htmlParser = new DOMParser();
     const htmlDoc = htmlParser.parseFromString(text, 'text/html');
-
-    // get styles from head
-    const styles = Array.from(htmlDoc.head.getElementsByTagName('style'))
-      .map((style) => style.outerHTML)
-      .join('');
-
-    // combine styles with body content
-    return styles + htmlDoc.body.innerHTML;
+    const body = htmlDoc.body;
+    return body.innerHTML;
   }, [activeTab]);
 
   const isEmpty = html === '';
@@ -62,12 +56,14 @@ export function HTMLCodeBlockView(props: NodeViewProps) {
             'mly-not-prose mly-rounded-lg mly-border mly-border-gray-200 mly-p-2',
             isEmpty && 'mly-min-h-[42px]'
           )}
-          // shadow DOM to prevent styles from leaking
           ref={(node) => {
-            if (node && !node.shadowRoot) {
-              const shadow = node.attachShadow({ mode: 'open' });
-              shadow.innerHTML = html;
+            if (!node || node?.shadowRoot) {
+              return;
             }
+            // shadow DOM to prevent styles from leaking
+            const shadow = node.attachShadow({ mode: 'open' });
+            const htmlWithStyles = `<style>blockquote,h1,h2,h3,img,li,ol,p,ul{margin-top:0;margin-bottom:0}</style>${html}`;
+            shadow.innerHTML = htmlWithStyles;
           }}
           contentEditable={false}
           onClick={() => {

--- a/packages/core/src/editor/nodes/html/html-view.tsx
+++ b/packages/core/src/editor/nodes/html/html-view.tsx
@@ -29,8 +29,14 @@ export function HTMLCodeBlockView(props: NodeViewProps) {
 
     const htmlParser = new DOMParser();
     const htmlDoc = htmlParser.parseFromString(text, 'text/html');
-    const body = htmlDoc.body;
-    return body.innerHTML;
+
+    // get styles from head
+    const styles = Array.from(htmlDoc.head.getElementsByTagName('style'))
+      .map((style) => style.outerHTML)
+      .join('');
+
+    // combine styles with body content
+    return styles + htmlDoc.body.innerHTML;
   }, [activeTab]);
 
   const isEmpty = html === '';
@@ -56,7 +62,13 @@ export function HTMLCodeBlockView(props: NodeViewProps) {
             'mly-not-prose mly-rounded-lg mly-border mly-border-gray-200 mly-p-2',
             isEmpty && 'mly-min-h-[42px]'
           )}
-          dangerouslySetInnerHTML={{ __html: html }}
+          // shadow DOM to prevent styles from leaking
+          ref={(node) => {
+            if (node && !node.shadowRoot) {
+              const shadow = node.attachShadow({ mode: 'open' });
+              shadow.innerHTML = html;
+            }
+          }}
           contentEditable={false}
           onClick={() => {
             if (!isEmpty) {

--- a/packages/render/src/maily.tsx
+++ b/packages/render/src/maily.tsx
@@ -302,7 +302,6 @@ export class Maily {
   private marksOrder = ['underline', 'bold', 'italic', 'textStyle', 'link'];
   private meta: MetaDescriptors = DEFAULT_META_TAGS;
   private htmlProps: HtmlProps = DEFAULT_HTML_PROPS;
-  private htmlStyles: Set<string> = new Set();
 
   constructor(content: JSONContent = { type: 'doc', content: [] }) {
     this.content = content;
@@ -509,7 +508,6 @@ export class Maily {
     const { preview } = this.config;
     const tags = meta(this.meta);
     const htmlProps = this.htmlProps;
-    const htmlStyles = Array.from(this.htmlStyles).join('\n');
 
     const markup = (
       <Html {...htmlProps}>
@@ -526,7 +524,7 @@ export class Maily {
           />
           <style
             dangerouslySetInnerHTML={{
-              __html: `@media only screen and (max-width:425px){.tab-row-full{width:100%!important}.tab-col-full{display:block!important;width:100%!important}.tab-pad{padding:0!important}} ${htmlStyles || ''}`,
+              __html: `blockquote,h1,h2,h3,img,li,ol,p,ul{margin-top:0;margin-bottom:0}@media only screen and (max-width:425px){.tab-row-full{width:100%!important}.tab-col-full{display:block!important;width:100%!important}.tab-pad{padding:0!important}}`,
             }}
           />
           {tags}
@@ -1736,17 +1734,8 @@ export class Maily {
       }, '') || '';
     const doc = parse(text);
 
-    // extract styles from head and add to htmlStyles collection
     const head = doc.querySelector('head');
-    if (head) {
-      head.querySelectorAll('style').forEach((style) => {
-        const cssContent = style.text || style.innerHTML;
-        if (cssContent) {
-          this.htmlStyles.add(cssContent);
-        }
-      });
-      head.remove();
-    }
+    head?.remove();
 
     const html = doc.toString();
     return (


### PR DESCRIPTION
- adds support for `style` tags inside custom HTML blocks
- fixes leakage of app styles into the HTML block preview
- removes default `0` margins applied on default html tags (`blockquote,h1,h2,h3,img,li,ol,p,ul`)

**Reasoning**

Most of the free HTML email templates and also templates generated by AI use <style> tag to define CSS classes instead of inline styles. A lot of users will want to copy-paste such templates or use the style tag when creating their own.

Custom style classes support:

https://github.com/user-attachments/assets/9d39d37b-46c9-4fe4-bc78-21a0fd8c8494
