### PR TITLE
feat: support border radius on image component

### DIFF
--- a/packages/core/src/editor/components/image-menu/image-bubble-menu.tsx
+++ b/packages/core/src/editor/components/image-menu/image-bubble-menu.tsx
@@ -87,27 +87,6 @@ export function ImageBubbleMenu(props: EditorBubbleMenuProps) {
             }}
           />
 
-          {state.isImageActive && (
-            <Select
-              label="Border Radius"
-              value={state?.borderRadius}
-              options={borderRadius.map((value) => ({
-                value: value.value.toString(),
-                label: value.name,
-              }))}
-              onValueChange={(value) => {
-                editor
-                  ?.chain()
-                  .updateAttributes('image', {
-                    borderRadius: Number(value),
-                  })
-                  .run();
-              }}
-              tooltip="Border Radius"
-              className="mly-capitalize"
-            />
-          )}
-
           <LinkInputPopover
             defaultValue={state?.imageSrc ?? ''}
             onValueChange={(value, isVariable) => {
@@ -156,6 +135,27 @@ export function ImageBubbleMenu(props: EditorBubbleMenuProps) {
 
         {state.isImageActive && state.imageSrc && (
           <>
+            <Divider />
+
+            <Select
+              label="Border Radius"
+              value={state?.borderRadius}
+              options={borderRadius.map((value) => ({
+                value: String(value.value),
+                label: value.name,
+              }))}
+              onValueChange={(value) => {
+                editor
+                  ?.chain()
+                  .updateAttributes('image', {
+                    borderRadius: Number(value),
+                  })
+                  .run();
+              }}
+              tooltip="Border Radius"
+              className="mly-capitalize"
+            />
+
             <Divider />
 
             <div className="mly-flex mly-space-x-0.5">

--- a/packages/core/src/editor/components/image-menu/image-bubble-menu.tsx
+++ b/packages/core/src/editor/components/image-menu/image-bubble-menu.tsx
@@ -11,6 +11,7 @@ import { Select } from '../ui/select';
 import { TooltipProvider } from '../ui/tooltip';
 import { ImageSize } from './image-size';
 import { useImageState } from './use-image-state';
+import { borderRadius } from '@/editor/utils/border-radius';
 
 export function ImageBubbleMenu(props: EditorBubbleMenuProps) {
   const { editor, appendTo } = props;
@@ -85,6 +86,27 @@ export function ImageBubbleMenu(props: EditorBubbleMenuProps) {
               }
             }}
           />
+
+          {state.isImageActive && (
+            <Select
+              label="Border Radius"
+              value={state?.borderRadius}
+              options={borderRadius.map((value) => ({
+                value: value.value.toString(),
+                label: value.name,
+              }))}
+              onValueChange={(value) => {
+                editor
+                  ?.chain()
+                  .updateAttributes('image', {
+                    borderRadius: Number(value),
+                  })
+                  .run();
+              }}
+              tooltip="Border Radius"
+              className="mly-capitalize"
+            />
+          )}
 
           <LinkInputPopover
             defaultValue={state?.imageSrc ?? ''}

--- a/packages/core/src/editor/components/image-menu/use-image-state.tsx
+++ b/packages/core/src/editor/components/image-menu/use-image-state.tsx
@@ -14,6 +14,7 @@ export const useImageState = (editor: Editor) => {
         alignment:
           editor.getAttributes('image')?.alignment ||
           editor.getAttributes('logo')?.alignment,
+        borderRadius: editor.getAttributes('image')?.borderRadius,
 
         logoSize: editor.getAttributes('logo')?.size || DEFAULT_LOGO_SIZE,
         imageSrc:

--- a/packages/core/src/editor/nodes/image/image-view.tsx
+++ b/packages/core/src/editor/nodes/image/image-view.tsx
@@ -113,7 +113,13 @@ export function ImageView(props: NodeViewProps) {
     [handleMouseDown, isPlaceholderImage]
   );
 
-  let { alignment = 'center', width, height, src } = node.attrs || {};
+  let {
+    alignment = 'center',
+    width,
+    height,
+    src,
+    borderRadius,
+  } = node.attrs || {};
 
   const {
     externalLink,
@@ -334,6 +340,7 @@ export function ImageView(props: NodeViewProps) {
               ...resizingStyle,
               cursor: 'default',
               marginBottom: 0,
+              borderRadius,
             }}
             draggable={editor.isEditable}
             className={cn(

--- a/packages/core/src/editor/nodes/image/image.ts
+++ b/packages/core/src/editor/nodes/image/image.ts
@@ -3,6 +3,8 @@ import { ReactNodeViewRenderer } from '@tiptap/react';
 import { DEFAULT_SECTION_SHOW_IF_KEY } from '../section/section';
 import { ImageView } from './image-view';
 
+const DEFAULT_IMAGE_BORDER_RADIUS = 0;
+
 export const ImageExtension = TiptapImage.extend({
   addAttributes() {
     return {
@@ -75,6 +77,18 @@ export const ImageExtension = TiptapImage.extend({
 
           return {
             'data-is-external-link-variable': 'true',
+          };
+        },
+      },
+
+      borderRadius: {
+        default: DEFAULT_IMAGE_BORDER_RADIUS,
+        parseHTML: (element) => {
+          return Number(element.getAttribute('data-border-radius'));
+        },
+        renderHTML: (attributes) => {
+          return {
+            'data-border-radius': attributes.borderRadius,
           };
         },
       },

--- a/packages/core/src/editor/utils/border-radius.ts
+++ b/packages/core/src/editor/utils/border-radius.ts
@@ -1,0 +1,18 @@
+export const borderRadius = [
+  {
+    name: 'Round',
+    value: 9999,
+  },
+  {
+    name: 'Smoother',
+    value: 16,
+  },
+  {
+    name: 'Smooth',
+    value: 8,
+  },
+  {
+    name: 'Sharp',
+    value: 0,
+  },
+];

--- a/packages/core/src/editor/utils/border-radius.ts
+++ b/packages/core/src/editor/utils/border-radius.ts
@@ -1,18 +1,22 @@
 export const borderRadius = [
   {
-    name: 'Round',
-    value: 9999,
-  },
-  {
-    name: 'Smoother',
-    value: 16,
+    name: 'Sharp',
+    value: 0,
   },
   {
     name: 'Smooth',
     value: 8,
   },
   {
-    name: 'Sharp',
-    value: 0,
+    name: 'Smoother',
+    value: 16,
+  },
+  {
+    name: 'Rounded',
+    value: 24,
+  },
+  {
+    name: 'Circle',
+    value: 9999,
   },
 ];

--- a/packages/render/src/maily.tsx
+++ b/packages/render/src/maily.tsx
@@ -1155,6 +1155,7 @@ export class Maily {
       alignment = 'center',
       externalLink = '',
       isExternalLinkVariable,
+      borderRadius,
     } = attrs || {};
 
     const shouldShow = this.shouldShow(node, options);
@@ -1187,6 +1188,7 @@ export class Maily {
           border: 'none',
           textDecoration: 'none',
           display: 'block', // Prevent unwanted spacing
+          borderRadius,
         }}
         title={title || alt || 'Image'}
       />

--- a/packages/render/src/maily.tsx
+++ b/packages/render/src/maily.tsx
@@ -1155,7 +1155,7 @@ export class Maily {
       alignment = 'center',
       externalLink = '',
       isExternalLinkVariable,
-      borderRadius,
+      borderRadius = 0,
     } = attrs || {};
 
     const shouldShow = this.shouldShow(node, options);


### PR DESCRIPTION
This PR adds border radius support to the image component, which is useful when using images as headers.

**Screenshots:**
<img width="931" alt="SCR-20250313-kido" src="https://github.com/user-attachments/assets/ee97b532-5a42-4e8a-8e8c-0363bb3d4cbd" />

<img width="1023" alt="SCR-20250313-khuc" src="https://github.com/user-attachments/assets/c4ea9ad5-f1cd-4b9b-b16a-65f77d36549a" />
