### PR TITLE
feat(render): allow container styles override

### DIFF
--- a/packages/render/src/maily.tsx
+++ b/packages/render/src/maily.tsx
@@ -90,14 +90,7 @@ export interface ThemeOptions {
     linkCardBadgeBackground: string;
     linkCardSubTitle: string;
   }>;
-  container?: Partial<{
-    maxWidth: string;
-    minWidth: string;
-    width: string;
-    marginLeft: string;
-    marginRight: string;
-    padding: string;
-  }>;
+  container?: Partial<CSSProperties>;
   fontSize?: Partial<{
     paragraph: Partial<{
       size: string;
@@ -556,25 +549,7 @@ export class Maily {
           {preview ? (
             <Preview id="__react-email-preview">{preview}</Preview>
           ) : null}
-          <Container
-            style={{
-              maxWidth:
-                containerStyles?.maxWidth || DEFAULT_THEME.container?.maxWidth,
-              minWidth:
-                containerStyles?.minWidth || DEFAULT_THEME.container?.minWidth,
-              width: containerStyles?.width || DEFAULT_THEME.container?.width,
-              marginLeft:
-                containerStyles?.marginLeft ||
-                DEFAULT_THEME.container?.marginLeft,
-              marginRight:
-                containerStyles?.marginRight ||
-                DEFAULT_THEME.container?.marginRight,
-              padding:
-                containerStyles?.padding || DEFAULT_THEME.container?.padding,
-            }}
-          >
-            {jsxNodes}
-          </Container>
+          <Container style={containerStyles}>{jsxNodes}</Container>
           {this.openTrackingPixel ? (
             <Img
               alt=""

--- a/packages/render/src/maily.tsx
+++ b/packages/render/src/maily.tsx
@@ -90,6 +90,14 @@ export interface ThemeOptions {
     linkCardBadgeBackground: string;
     linkCardSubTitle: string;
   }>;
+  container?: Partial<{
+    maxWidth: string;
+    minWidth: string;
+    width: string;
+    marginLeft: string;
+    marginRight: string;
+    padding: string;
+  }>;
   fontSize?: Partial<{
     paragraph: Partial<{
       size: string;
@@ -172,6 +180,14 @@ const DEFAULT_THEME: ThemeOptions = {
     linkCardBadgeText: '#111827',
     linkCardBadgeBackground: '#FEF08A',
     linkCardSubTitle: '#6B7280',
+  },
+  container: {
+    maxWidth: '600px',
+    minWidth: '300px',
+    width: '100%',
+    marginLeft: 'auto',
+    marginRight: 'auto',
+    padding: '0.5rem',
   },
   fontSize: {
     paragraph: {
@@ -510,7 +526,8 @@ export class Maily {
     const { preview } = this.config;
     const tags = meta(this.meta);
     const htmlProps = this.htmlProps;
-
+    const containerStyles = this.config.theme?.container;
+    console.log('STYLES!', containerStyles);
     const markup = (
       <Html {...htmlProps}>
         <Head>
@@ -541,12 +558,19 @@ export class Maily {
           ) : null}
           <Container
             style={{
-              maxWidth: '600px',
-              minWidth: '300px',
-              width: '100%',
-              marginLeft: 'auto',
-              marginRight: 'auto',
-              padding: '0.5rem',
+              maxWidth:
+                containerStyles?.maxWidth || DEFAULT_THEME.container?.maxWidth,
+              minWidth:
+                containerStyles?.minWidth || DEFAULT_THEME.container?.minWidth,
+              width: containerStyles?.width || DEFAULT_THEME.container?.width,
+              marginLeft:
+                containerStyles?.marginLeft ||
+                DEFAULT_THEME.container?.marginLeft,
+              marginRight:
+                containerStyles?.marginRight ||
+                DEFAULT_THEME.container?.marginRight,
+              padding:
+                containerStyles?.padding || DEFAULT_THEME.container?.padding,
             }}
           >
             {jsxNodes}

--- a/packages/render/src/maily.tsx
+++ b/packages/render/src/maily.tsx
@@ -527,7 +527,7 @@ export class Maily {
     const tags = meta(this.meta);
     const htmlProps = this.htmlProps;
     const containerStyles = this.config.theme?.container;
-    console.log('STYLES!', containerStyles);
+
     const markup = (
       <Html {...htmlProps}>
         <Head>


### PR DESCRIPTION
- Add possibility to override the container styles via theme

Default container:
<img width="1800" alt="image" src="https://github.com/user-attachments/assets/c051fb81-7ea7-48af-a691-db631578c9b2" />

Overriden styles using:

```
maily.setTheme({
  container: {
    maxWidth: '100%',
    minWidth: '100%',
    marginLeft: 'none',
    marginRight: 'none',
  }
 });
```

<img width="1800" alt="image" src="https://github.com/user-attachments/assets/5a5e5f4d-673e-4ae1-83bb-a2a53e40ab19" />


