### PR TITLE
feat(core): add possibility to hide context menu

### DIFF
--- a/packages/core/src/editor/index.tsx
+++ b/packages/core/src/editor/index.tsx
@@ -39,7 +39,7 @@ export type EditorProps = {
   extensions?: AnyExtension[];
   config?: {
     hasMenuBar?: boolean;
-    hasContextMenu?: boolean;
+    hideContextMenu?: boolean;
     spellCheck?: boolean;
     wrapClassName?: string;
     toolbarClassName?: string;
@@ -58,7 +58,7 @@ export function Editor(props: EditorProps) {
       contentClassName = '',
       bodyClassName = '',
       hasMenuBar = true,
-      hasContextMenu = true,
+      hideContextMenu = false,
       spellCheck = false,
       autofocus = 'end',
       immediatelyRender = false,
@@ -150,7 +150,7 @@ export function Editor(props: EditorProps) {
           <EditorContent editor={editor} />
           <SectionBubbleMenu editor={editor} appendTo={menuContainerRef} />
           <ColumnsBubbleMenu editor={editor} appendTo={menuContainerRef} />
-          {hasContextMenu && <ContentMenu editor={editor} />}
+          {!hideContextMenu && <ContentMenu editor={editor} />}
           <VariableBubbleMenu editor={editor} appendTo={menuContainerRef} />
           <RepeatBubbleMenu editor={editor} appendTo={menuContainerRef} />
           <HTMLBubbleMenu editor={editor} appendTo={menuContainerRef} />

--- a/packages/core/src/editor/index.tsx
+++ b/packages/core/src/editor/index.tsx
@@ -39,6 +39,7 @@ export type EditorProps = {
   extensions?: AnyExtension[];
   config?: {
     hasMenuBar?: boolean;
+    hasContextMenu?: boolean;
     spellCheck?: boolean;
     wrapClassName?: string;
     toolbarClassName?: string;
@@ -57,6 +58,7 @@ export function Editor(props: EditorProps) {
       contentClassName = '',
       bodyClassName = '',
       hasMenuBar = true,
+      hasContextMenu = true,
       spellCheck = false,
       autofocus = 'end',
       immediatelyRender = false,
@@ -148,7 +150,7 @@ export function Editor(props: EditorProps) {
           <EditorContent editor={editor} />
           <SectionBubbleMenu editor={editor} appendTo={menuContainerRef} />
           <ColumnsBubbleMenu editor={editor} appendTo={menuContainerRef} />
-          <ContentMenu editor={editor} />
+          {hasContextMenu && <ContentMenu editor={editor} />}
           <VariableBubbleMenu editor={editor} appendTo={menuContainerRef} />
           <RepeatBubbleMenu editor={editor} appendTo={menuContainerRef} />
           <HTMLBubbleMenu editor={editor} appendTo={menuContainerRef} />


### PR DESCRIPTION
If I want to disable all blocks and allow only the use of variables for the field, one can still try to add content via the context menu. But the context menu has nothing to offer in this case.

Allow to hide the context menu with the use of config option:
```
<Editor
  config={{
    hideContextMenu: true
  }}
/>
```