### PR TITLE
feat(core): add allowExternalImages config option

### DIFF
--- a/packages/core/src/editor/components/image-menu/image-bubble-menu.tsx
+++ b/packages/core/src/editor/components/image-menu/image-bubble-menu.tsx
@@ -20,7 +20,7 @@ import {
 } from '@/editor/nodes/image/image-view';
 
 export function ImageBubbleMenu(props: EditorBubbleMenuProps) {
-  const { editor, appendTo } = props;
+  const { editor, appendTo, allowExternal } = props;
   if (!editor) {
     return null;
   }
@@ -122,7 +122,7 @@ export function ImageBubbleMenu(props: EditorBubbleMenuProps) {
             isVariable={state.isSrcVariable}
           />
 
-          {state.isImageActive && (
+          {state.isImageActive && allowExternal && (
             <LinkInputPopover
               defaultValue={state?.imageExternalLink ?? ''}
               onValueChange={(value, isVariable) => {

--- a/packages/core/src/editor/components/inline-image-menu/inline-image-bubble-menu.tsx
+++ b/packages/core/src/editor/components/inline-image-menu/inline-image-bubble-menu.tsx
@@ -13,7 +13,7 @@ import {
 } from '@/editor/nodes/inline-image/inline-image';
 
 export function InlineImageBubbleMenu(props: EditorBubbleMenuProps) {
-  const { editor, appendTo } = props;
+  const { editor, appendTo, allowExternal } = props;
   if (!editor) {
     return null;
   }
@@ -64,21 +64,23 @@ export function InlineImageBubbleMenu(props: EditorBubbleMenuProps) {
             isVariable={state.isSrcVariable}
           />
 
-          <LinkInputPopover
-            defaultValue={state?.imageExternalLink ?? ''}
-            onValueChange={(value, isVariable) => {
-              editor
-                ?.chain()
-                .updateAttributes('inlineImage', {
-                  externalLink: value,
-                  isExternalLinkVariable: isVariable ?? false,
-                })
-                .run();
-            }}
-            tooltip="External URL"
-            editor={editor}
-            isVariable={state.isExternalLinkVariable}
-          />
+          {allowExternal && (
+            <LinkInputPopover
+              defaultValue={state?.imageExternalLink ?? ''}
+              onValueChange={(value, isVariable) => {
+                editor
+                  ?.chain()
+                  .updateAttributes('inlineImage', {
+                    externalLink: value,
+                    isExternalLinkVariable: isVariable ?? false,
+                  })
+                  .run();
+              }}
+              tooltip="External URL"
+              editor={editor}
+              isVariable={state.isExternalLinkVariable}
+            />
+          )}
 
           <ImageSize
             dimension="height"

--- a/packages/core/src/editor/components/text-menu/text-bubble-menu.tsx
+++ b/packages/core/src/editor/components/text-menu/text-bubble-menu.tsx
@@ -29,6 +29,7 @@ export interface BubbleMenuItem {
 
 export type EditorBubbleMenuProps = Omit<BubbleMenuProps, 'children'> & {
   appendTo?: React.RefObject<any>;
+  allowExternal?: boolean;
 };
 
 export function TextBubbleMenu(props: EditorBubbleMenuProps) {

--- a/packages/core/src/editor/index.tsx
+++ b/packages/core/src/editor/index.tsx
@@ -39,6 +39,7 @@ export type EditorProps = {
   extensions?: AnyExtension[];
   config?: {
     hasMenuBar?: boolean;
+    allowExternalImages?: boolean;
     hideContextMenu?: boolean;
     spellCheck?: boolean;
     wrapClassName?: string;
@@ -59,6 +60,7 @@ export function Editor(props: EditorProps) {
       bodyClassName = '',
       hasMenuBar = true,
       hideContextMenu = false,
+      allowExternalImages = true,
       spellCheck = false,
       autofocus = 'end',
       immediatelyRender = false,
@@ -145,7 +147,11 @@ export function Editor(props: EditorProps) {
           )}
         >
           <TextBubbleMenu editor={editor} appendTo={menuContainerRef} />
-          <ImageBubbleMenu editor={editor} appendTo={menuContainerRef} />
+          <ImageBubbleMenu
+            allowExternal={allowExternalImages}
+            editor={editor}
+            appendTo={menuContainerRef}
+          />
           <SpacerBubbleMenu editor={editor} appendTo={menuContainerRef} />
           <EditorContent editor={editor} />
           <SectionBubbleMenu editor={editor} appendTo={menuContainerRef} />
@@ -154,7 +160,11 @@ export function Editor(props: EditorProps) {
           <VariableBubbleMenu editor={editor} appendTo={menuContainerRef} />
           <RepeatBubbleMenu editor={editor} appendTo={menuContainerRef} />
           <HTMLBubbleMenu editor={editor} appendTo={menuContainerRef} />
-          <InlineImageBubbleMenu editor={editor} appendTo={menuContainerRef} />
+          <InlineImageBubbleMenu
+            allowExternal={allowExternalImages}
+            editor={editor}
+            appendTo={menuContainerRef}
+          />
         </div>
       </div>
     </MailyProvider>


### PR DESCRIPTION
Add `allowExternalImages` config option to hide external URL option in the image popup.

```
<Editor
  config={[
    allowExternalImages: false,
  ]}
```

<img width="836" alt="image" src="https://github.com/user-attachments/assets/d272bb9e-b718-4ff8-a986-9be4efb3fbca" />