### PR TITLE
Fix meta hash helper name

### DIFF
--- a/packages/render/src/meta.tsx
+++ b/packages/render/src/meta.tsx
@@ -33,11 +33,11 @@ export function meta(meta: MetaDescriptors) {
       // only filter unique meta tags
       // so that we don't have duplicate meta tags
       .filter((meta, index, self) => {
-        const meta_hash = has(meta);
+        const meta_hash = hash(meta);
         return (
           index ===
           self.findIndex((t) => {
-            return has(t) === meta_hash;
+            return hash(t) === meta_hash;
           })
         );
       })
@@ -70,7 +70,7 @@ function process(props: MetaDescriptor) {
  * for that we have to sort the object keys
  * and then stringify it and hash it
  */
-function has(meta: MetaDescriptor) {
+function hash(meta: MetaDescriptor) {
   const sortedMeta = Object.keys(meta)
     .sort()
     .reduce((acc, key) => {


### PR DESCRIPTION
## Summary
- fix helper name for meta tag hashing

## Testing
- `npm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fd046e5a4832e8c2421139a04f4ad