### PR TITLE
fix: dropdown and popover positioning

### DIFF
--- a/packages/core/src/editor/components/popover.tsx
+++ b/packages/core/src/editor/components/popover.tsx
@@ -15,25 +15,35 @@ const PopoverTrigger: React.FC<
 
 const PopoverContent = React.forwardRef<
   React.ElementRef<typeof PopoverPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
->(({ className, align = 'center', sideOffset = 4, ...props }, ref) => (
-  <PopoverPrimitive.Portal>
-    <PopoverPrimitive.Content
-      ref={ref}
-      align={align}
-      sideOffset={sideOffset}
-      className={cn(
-        'mly:z-9999 mly:w-72 mly:rounded-md mly:border mly:border-gray-200 mly:bg-white mly:p-4 mly:text-gray-950 mly:shadow-md mly:outline-hidden',
-        'mly-editor',
-        className
-      )}
-      {...props}
-    />
-  </PopoverPrimitive.Portal>
-)) as React.ForwardRefExoticComponent<
-  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content> &
-    React.RefAttributes<React.ElementRef<typeof PopoverPrimitive.Content>>
->;
+  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content> & {
+    portal?: boolean;
+  }
+>(
+  (
+    { className, align = 'center', sideOffset = 4, portal = false, ...props },
+    ref
+  ) => {
+    const content = (
+      <PopoverPrimitive.Content
+        ref={ref}
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          'mly:z-9999 mly:w-72 mly:rounded-md mly:border mly:border-gray-200 mly:bg-white mly:p-4 mly:text-gray-950 mly:shadow-md mly:outline-hidden',
+          'mly-editor',
+          className
+        )}
+        {...props}
+      />
+    );
+
+    if (!portal) {
+      return content;
+    }
+
+    return <PopoverPrimitive.Portal>{content}</PopoverPrimitive.Portal>;
+  }
+);
 
 PopoverContent.displayName = PopoverPrimitive.Content.displayName;
 

--- a/packages/core/src/editor/components/ui/dropdown-menu.tsx
+++ b/packages/core/src/editor/components/ui/dropdown-menu.tsx
@@ -57,9 +57,11 @@ DropdownMenuSubContent.displayName =
 
 const DropdownMenuContent = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
->(({ className, sideOffset = 4, ...props }, ref) => (
-  <DropdownMenuPrimitive.Portal>
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content> & {
+    portal?: boolean;
+  }
+>(({ className, sideOffset = 4, portal = false, ...props }, ref) => {
+  const content = (
     <DropdownMenuPrimitive.Content
       ref={ref}
       sideOffset={sideOffset}
@@ -69,8 +71,14 @@ const DropdownMenuContent = React.forwardRef<
       )}
       {...props}
     />
-  </DropdownMenuPrimitive.Portal>
-));
+  );
+
+  if (!portal) {
+    return content;
+  }
+
+  return <DropdownMenuPrimitive.Portal>{content}</DropdownMenuPrimitive.Portal>;
+});
 DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;
 
 const DropdownMenuItem = React.forwardRef<

--- a/packages/core/src/editor/index.tsx
+++ b/packages/core/src/editor/index.tsx
@@ -49,6 +49,8 @@ export type EditorProps = {
     immediatelyRender?: boolean;
   };
   editable?: boolean;
+  scrollThreshold?: number;
+  scrollMargin?: number;
 } & ParitialMailContextType;
 
 export function Editor(props: EditorProps) {
@@ -71,6 +73,8 @@ export function Editor(props: EditorProps) {
     blocks = DEFAULT_SLASH_COMMANDS,
     editable = true,
     placeholderUrl = DEFAULT_PLACEHOLDER_URL,
+    scrollThreshold = 40,
+    scrollMargin = 40,
   } = props;
 
   const formattedContent = useMemo(() => {
@@ -102,6 +106,8 @@ export function Editor(props: EditorProps) {
   const menuContainerRef = useRef(null);
   const editor = useEditor({
     editorProps: {
+      scrollThreshold,
+      scrollMargin,
       attributes: {
         class: cn('mly:prose mly:w-full', contentClassName),
         spellCheck: spellCheck ? 'true' : 'false',


### PR DESCRIPTION
This pull request introduces enhancements to the `Popover` and `DropdownMenu` components by adding a `portal` prop for more flexible rendering, and updates the `Editor` component to support scroll-related customization. These changes improve the flexibility and configurability of the components.

### Enhancements to `Popover` and `DropdownMenu` Components:
* **`PopoverContent` Component**: Added a `portal` prop to conditionally wrap the content in a `PopoverPrimitive.Portal`. This allows developers to control whether the content is rendered inside a portal. [[1]](diffhunk://#diff-e9c74f5d43ba40806c0f3a31e6354256d393ac8232e2be2df12348297729c93cL18-R26) [[2]](diffhunk://#diff-e9c74f5d43ba40806c0f3a31e6354256d393ac8232e2be2df12348297729c93cL32-R46)
* **`DropdownMenuContent` Component**: Similarly, introduced a `portal` prop to conditionally wrap the content in a `DropdownMenuPrimitive.Portal`, providing the same flexibility as the `PopoverContent` component. [[1]](diffhunk://#diff-6e8f2f9fe10add4e097626a3a275d9d5476edf6b4fe9f6323966d7d866e043f7L60-R64) [[2]](diffhunk://#diff-6e8f2f9fe10add4e097626a3a275d9d5476edf6b4fe9f6323966d7d866e043f7L72-R81)

### Updates to the `Editor` Component:
* **New Props for Scroll Customization**: Added `scrollThreshold` and `scrollMargin` props to the `EditorProps` type, allowing developers to customize the scroll behavior of the editor.
* **Default Values for New Props**: Set default values for `scrollThreshold` and `scrollMargin` to `40` in the `Editor` component's props destructuring.
* **Integration with `useEditor`**: Passed the new `scrollThreshold` and `scrollMargin` props to the `editorProps` configuration in the `useEditor` hook.

Resolves #207 