### PR TITLE
Improve HTML to plain text conversion in Maily

### DIFF
--- a/packages/render/src/render.test.ts
+++ b/packages/render/src/render.test.ts
@@ -1,4 +1,4 @@
-import { Maily, render } from './index';
+import { Maily, render, htmlToPlainText } from './index';
 import { Preheader } from './preheader';
 
 describe('render', () => {
@@ -554,5 +554,63 @@ describe('render', () => {
 
       expect(result).toBe('Order #ORD-789 for Alice Smith');
     });
+  });
+});
+
+describe("htmlToPlainText", () => {
+  test("strips basic HTML tags", async () => {
+    const result = await htmlToPlainText("<p>Hello <strong>world</strong></p>");
+    expect(result).toBe("Hello world");
+  });
+
+  test("converts links to text (url) format", async () => {
+    const result = await htmlToPlainText(
+      '<a href="https://example.com">Click here</a>',
+    );
+    expect(result).toBe("Click here (https://example.com)");
+  });
+
+  test("preserves bare URL when link text matches URL", async () => {
+    const result = await htmlToPlainText(
+      '<a href="https://example.com">https://example.com</a>',
+    );
+    expect(result).toBe("https://example.com");
+  });
+
+  test("converts <br> to newlines", async () => {
+    const result = await htmlToPlainText("Line 1<br>Line 2<br/>Line 3");
+    expect(result).toBe("Line 1\nLine 2\nLine 3");
+  });
+
+  test("converts <hr> to separator", async () => {
+    const result = await htmlToPlainText("Above<hr>Below");
+    expect(result).toContain("---");
+    expect(result).toContain("Above");
+    expect(result).toContain("Below");
+  });
+
+  test("decodes HTML entities", async () => {
+    const result = await htmlToPlainText("&amp; &lt; &gt; &quot; &#39; &nbsp; &#65;");
+    expect(result).toBe("& < > \" ' A");
+  });
+
+  test("normalizes excessive whitespace", async () => {
+    const result = await htmlToPlainText(
+      "<p>  Too   many   spaces  </p><p></p><p></p><p></p><p>After gap</p>",
+    );
+    expect(result).not.toMatch(/\n{3,}/);
+    expect(result).toContain("Too many spaces");
+    expect(result).toContain("After gap");
+  });
+
+  test("handles empty string", async () => {
+    expect(await htmlToPlainText("")).toBe("");
+  });
+
+  test("handles block-level elements as line breaks", async () => {
+    const result = await htmlToPlainText("<div>Block 1</div><div>Block 2</div>");
+    expect(result).toContain("Block 1");
+    expect(result).toContain("Block 2");
+    expect(result).toMatch(/Block 1\n+Block 2/);
   });
 });

--- a/packages/render/src/render.ts
+++ b/packages/render/src/render.ts
@@ -14,3 +14,64 @@ export async function render(
 
   return maily.render(rest);
 }
+
+export async function htmlToPlainText(html: string): string {
+  let text = html;
+
+  // Replace <br> and <br/> with newlines                                                                           
+  text = text.replace(/<br\s*\/?>/gi, "\n");
+
+  // Replace <hr> with separator                                                   
+  text = text.replace(/<hr\s*\/?>/gi, "\n---\n");
+
+  // Replace block-level closing tags with newlines
+  text = text.replace(
+    /<\/(p|div|h[1-6]|li|tr|blockquote|section|article|header|footer)>/gi,
+    "\n",
+  );
+
+  // Convert links: <a href="url">text</a> → "text (url)"
+  text = text.replace(
+    /<a\s[^>]*href=["']([^"']*)["'][^>]*>([\s\S]*?)<\/a>/gi,
+    (_, url: string, linkText: string) => {
+      const cleanLinkText = linkText.replace(/<[^>]*>/g, "").trim();
+      if (!cleanLinkText || cleanLinkText === url) {
+        return url;
+      }
+      return `${cleanLinkText} (${url})`;
+    },
+  );
+
+  // Strip all remaining HTML tags
+  text = text.replace(/<[^>]*>/g, "");
+
+  // Decode common HTML entities
+  text = text
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&apos;/g, "'")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&#(\d+);/g, (_, code: string) =>
+      String.fromCharCode(Number.parseInt(code, 10)),
+    )
+    .replace(/&#x([0-9a-fA-F]+);/g, (_, hex: string) =>
+      String.fromCharCode(Number.parseInt(hex, 16)),
+    );
+
+  // Normalize whitespace: collapse multiple spaces on the same line
+  text = text.replace(/[ \t]+/g, " ");
+
+  // Collapse 3+ consecutive newlines to 2
+  text = text.replace(/\n{3,}/g, "\n\n");
+
+  // Trim each line
+  text = text
+    .split("\n")
+    .map((line) => line.trim())
+    .join("\n");
+
+  return text.trim();
+}


### PR DESCRIPTION
Hello, I was working with Maily in my own app and ended up writing a much fancier HTML to plain text conversion that will be closer to what someone would actually want to receive. It handles a few different scenarios I found in testing. I think it would be useful for the app. I was not sure how you would want to integrate this so I only added the function to the render code and added tests, I would leave any integration up to you. I don't like to add a lot of comments but it's extremely non-obvious what most of this does.

Cheers!