### PR TITLE
Fix stretched images by letting height follow width

### DIFF
--- a/packages/core/src/editor/components/image-menu/image-bubble-menu.tsx
+++ b/packages/core/src/editor/components/image-menu/image-bubble-menu.tsx
@@ -1,11 +1,9 @@
 import { AllowedLogoSize, allowedLogoSize } from '@/editor/nodes/logo/logo';
-import { getNewHeight, getNewWidth } from '@/editor/utils/aspect-ratio';
 import { borderRadius } from '@/editor/utils/border-radius';
 import { BubbleMenu } from '@tiptap/react';
-import { ImageDown, LockIcon, LockOpenIcon } from 'lucide-react';
+import { ImageDown } from 'lucide-react';
 import { sticky } from 'tippy.js';
 import { AlignmentSwitch } from '../alignment-switch';
-import { BubbleMenuButton } from '../bubble-menu-button';
 import { ShowPopover } from '../show-popover';
 import { EditorBubbleMenuProps } from '../text-menu/text-bubble-menu';
 import { Divider } from '../ui/divider';
@@ -14,10 +12,7 @@ import { Select } from '../ui/select';
 import { TooltipProvider } from '../ui/tooltip';
 import { ImageSize } from './image-size';
 import { useImageState } from './use-image-state';
-import {
-  IMAGE_MAX_HEIGHT,
-  IMAGE_MAX_WIDTH,
-} from '@/editor/nodes/image/image-view';
+import { IMAGE_MAX_WIDTH } from '@/editor/nodes/image/image-view';
 
 export function ImageBubbleMenu(props: EditorBubbleMenuProps) {
   const { editor, appendTo } = props;
@@ -46,8 +41,6 @@ export function ImageBubbleMenu(props: EditorBubbleMenuProps) {
       maxWidth: '100%',
     },
   };
-
-  const { lockAspectRatio } = state;
 
   return (
     <BubbleMenu
@@ -170,94 +163,14 @@ export function ImageBubbleMenu(props: EditorBubbleMenuProps) {
                 value={state?.width ?? ''}
                 onValueChange={(value) => {
                   const width = Math.min(Number(value) || 0, IMAGE_MAX_WIDTH);
-                  const currentHeight = Number(state.height) || 0;
-                  const currentWidth = Number(state.width) || 0;
-                  const hasValidAspectRatio =
-                    state.aspectRatio &&
-                    isFinite(state.aspectRatio) &&
-                    state.aspectRatio > 0;
-                  const currentAspectRatio = hasValidAspectRatio
-                    ? state.aspectRatio
-                    : currentHeight > 0
-                      ? currentWidth / currentHeight
-                      : 1;
-                  const isHeightAuto =
-                    !state.height || state.height === 'auto';
-                  const shouldUpdateHeight =
-                    (lockAspectRatio || isHeightAuto) &&
-                    value &&
-                    (hasValidAspectRatio || currentHeight > 0);
 
                   editor
                     ?.chain()
                     .updateAttributes('image', {
                       width: String(width),
-                      ...(shouldUpdateHeight
-                        ? {
-                            height: String(
-                              getNewHeight(width, currentAspectRatio)
-                            ),
-                          }
-                        : {}),
                     })
                     .run();
                 }}
-              />
-              <ImageSize
-                dimension="height"
-                value={state?.height ?? ''}
-                onValueChange={(value) => {
-                  const height = Number(value) || 0;
-                  const currentHeight = Number(state.height) || 0;
-                  const currentWidth = Number(state.width) || 0;
-                  const hasValidAspectRatio =
-                    state.aspectRatio &&
-                    isFinite(state.aspectRatio) &&
-                    state.aspectRatio > 0;
-                  const currentAspectRatio = hasValidAspectRatio
-                    ? state.aspectRatio
-                    : currentHeight > 0
-                      ? currentWidth / currentHeight
-                      : 1;
-                  const isWidthAuto = !state.width || state.width === 'auto';
-                  const shouldUpdateWidth =
-                    (lockAspectRatio || isWidthAuto) &&
-                    value &&
-                    (hasValidAspectRatio || currentWidth > 0);
-
-                  editor
-                    ?.chain()
-                    .updateAttributes('image', {
-                      height: String(height),
-                      ...(shouldUpdateWidth
-                        ? {
-                            width: String(
-                              getNewWidth(height, currentAspectRatio)
-                            ),
-                          }
-                        : {}),
-                    })
-                    .run();
-                }}
-              />
-
-              <BubbleMenuButton
-                isActive={() => lockAspectRatio}
-                command={() => {
-                  const width = Number(state.width) || 0;
-                  const height = Number(state.height) || 0;
-                  const aspectRatio = width / height;
-
-                  editor
-                    ?.chain()
-                    .updateAttributes('image', {
-                      lockAspectRatio: !lockAspectRatio,
-                      aspectRatio,
-                    })
-                    .run();
-                }}
-                icon={lockAspectRatio ? LockIcon : LockOpenIcon}
-                tooltip="Lock Aspect Ratio"
               />
             </div>
           </>

--- a/packages/core/src/editor/components/image-menu/use-image-state.tsx
+++ b/packages/core/src/editor/components/image-menu/use-image-state.tsx
@@ -8,7 +8,6 @@ export const useImageState = (editor: Editor) => {
     selector: ({ editor }) => {
       return {
         width: String(editor.getAttributes('image').width),
-        height: String(editor.getAttributes('image').height),
         isImageActive: editor.isActive('image'),
         isLogoActive: editor.isActive('logo'),
         alignment:
@@ -28,9 +27,6 @@ export const useImageState = (editor: Editor) => {
         imageExternalLink: editor.getAttributes('image')?.externalLink || '',
         isExternalLinkVariable:
           editor.getAttributes('image')?.isExternalLinkVariable,
-
-        lockAspectRatio: editor.getAttributes('image')?.lockAspectRatio,
-        aspectRatio: editor.getAttributes('image')?.aspectRatio,
 
         currentShowIfKey:
           editor.getAttributes('image')?.showIfKey ||

--- a/packages/core/src/editor/nodes/image/image-view.tsx
+++ b/packages/core/src/editor/nodes/image/image-view.tsx
@@ -10,11 +10,9 @@ import { Ban, BracesIcon, GrabIcon, ImageOffIcon, Loader2 } from 'lucide-react';
 import { useImageUploadOptions } from '@/editor/extensions/image-upload/image-upload';
 import { cn } from '@/editor/utils/classname';
 import { useEvent } from '@/editor/utils/use-event';
-import { getAspectRatio, getNewHeight } from '@/editor/utils/aspect-ratio';
 
 const MIN_WIDTH = 20;
 export const IMAGE_MAX_WIDTH = 600;
-export const IMAGE_MAX_HEIGHT = 400;
 
 export type ImageStatus = 'idle' | 'loading' | 'loaded' | 'error';
 
@@ -31,7 +29,7 @@ export function ImageView(props: NodeViewProps) {
   const imgRef = useRef<HTMLImageElement>(null);
 
   const [resizingStyle, setResizingStyle] = useState<
-    Pick<CSSProperties, 'width' | 'height'> | undefined
+    Pick<CSSProperties, 'width'> | undefined
   >();
 
   const [isDraggingOver, setIsDraggingOver] = useState(false);
@@ -54,19 +52,14 @@ export function ImageView(props: NodeViewProps) {
       event.preventDefault();
       const direction = event.currentTarget.dataset.direction || '--';
       const initialXPosition = event.clientX;
-      const initialYPosition = event.clientY;
       const currentWidth = imgRef.current.width;
-      const currentHeight = imgRef.current.height;
       let newWidth = currentWidth;
-      let newHeight = currentHeight;
       const transformX = direction[1] === 'w' ? -1 : 1;
-      const transformY = direction[0] === 'n' ? -1 : 1;
 
       const removeListeners = () => {
         window.removeEventListener('mousemove', mouseMoveHandler);
         window.removeEventListener('mouseup', removeListeners);
-        const aspectRatio = getAspectRatio(newWidth, newHeight);
-        updateAttributes({ width: newWidth, height: newHeight, aspectRatio });
+        updateAttributes({ width: newWidth });
         setResizingStyle(undefined);
       };
 
@@ -75,30 +68,14 @@ export function ImageView(props: NodeViewProps) {
           currentWidth + transformX * (event.clientX - initialXPosition),
           MIN_WIDTH
         );
-        newHeight = Math.max(
-          currentHeight + transformY * (event.clientY - initialYPosition),
-          MIN_WIDTH
-        );
 
         if (newWidth > imageParentWidth) {
           newWidth = imageParentWidth;
         }
-        if (newHeight > IMAGE_MAX_HEIGHT) {
-          newHeight = IMAGE_MAX_HEIGHT;
-        }
 
-        // If aspect ratio is locked, calculate height based on aspect ratio
-        if (node.attrs.lockAspectRatio) {
-          const aspectRatio =
-            node.attrs.aspectRatio &&
-            isFinite(node.attrs.aspectRatio) &&
-            node.attrs.aspectRatio > 0
-              ? node.attrs.aspectRatio
-              : currentWidth / currentHeight;
-          newHeight = getNewHeight(newWidth, aspectRatio);
-        }
-
-        setResizingStyle({ width: newWidth, height: newHeight });
+        // Width is the only authored dimension; height follows via `auto`
+        // so the aspect ratio is always preserved.
+        setResizingStyle({ width: newWidth });
         // If mouse is up, remove event listeners
         if (!event.buttons) {
           return removeListeners();
@@ -137,22 +114,14 @@ export function ImageView(props: NodeViewProps) {
     [handleMouseDown, isPlaceholderImage]
   );
 
-  let {
-    alignment = 'center',
-    width,
-    height,
-    src,
-    borderRadius,
-  } = node.attrs || {};
+  let { alignment = 'center', width, src, borderRadius } = node.attrs || {};
 
   const {
     externalLink,
     isExternalLinkVariable,
     isSrcVariable,
     showIfKey,
-    aspectRatio: defaultAspectRatio,
     borderRadius: _,
-    lockAspectRatio,
     ...attrs
   } = node.attrs || {};
 
@@ -209,9 +178,9 @@ export function ImageView(props: NodeViewProps) {
     img.src = src;
     img.onload = () => {
       setStatus('loaded');
-      // for some reason Apple Mail doesn't respect the width and height attributes
-      // update the dimensions to ensure that the image is not stretched
-      const { naturalWidth, naturalHeight } = img;
+      // for some reason Apple Mail doesn't respect the width attribute
+      // set a concrete width so the image is not stretched; height stays auto
+      const { naturalWidth } = img;
       const wrapper = wrapperRef?.current;
 
       if (!wrapper || width !== 'auto' || !naturalWidth) {
@@ -219,16 +188,9 @@ export function ImageView(props: NodeViewProps) {
       }
 
       const wrapperWidth = wrapper.offsetWidth;
-      const aspectRatio = getAspectRatio(naturalWidth, naturalHeight);
-      const calculatedHeight = Math.min(
-        getNewHeight(wrapperWidth, aspectRatio),
-        naturalHeight
-      );
 
       updateAttributes({
         width: Math.min(wrapperWidth, naturalWidth),
-        height: Math.min(calculatedHeight, naturalHeight),
-        aspectRatio,
       });
     };
     img.onerror = () => {
@@ -302,7 +264,6 @@ export function ImageView(props: NodeViewProps) {
         ...(hasImageSrc && status === 'loaded'
           ? {
               width: width && width !== 'auto' ? `${width}px` : undefined,
-              height: height && height !== 'auto' ? `${height}px` : undefined,
               ...resizingStyle,
             }
           : {}),
@@ -328,26 +289,22 @@ export function ImageView(props: NodeViewProps) {
         : {})}
     >
       {!hasImageSrc && status === 'idle' && (
-        <ImageStatusLabel
-          status="idle"
-          minHeight={height}
-          isDropZone={isDroppable}
-        />
+        <ImageStatusLabel status="idle" isDropZone={isDroppable} />
       )}
 
       {!hasImageSrc && status === 'loading' && !isSrcVariable && (
-        <ImageStatusLabel status="loading" minHeight={height} />
+        <ImageStatusLabel status="loading" />
       )}
 
       {hasImageSrc && isSrcVariable && (
-        <ImageStatusLabel status="variable" minHeight={height} />
+        <ImageStatusLabel status="variable" />
       )}
 
       {hasImageSrc && status === 'loading' && !isSrcVariable && (
-        <ImageStatusLabel status="loading" minHeight={height} />
+        <ImageStatusLabel status="loading" />
       )}
       {hasImageSrc && status === 'error' && !isSrcVariable && (
-        <ImageStatusLabel status="error" minHeight={height} />
+        <ImageStatusLabel status="error" />
       )}
 
       {isDroppable && (
@@ -376,11 +333,7 @@ export function ImageView(props: NodeViewProps) {
                 : width && width !== 'auto'
                   ? `${width}px`
                   : 'auto',
-              height: resizingStyle?.height
-                ? `${resizingStyle.height}px`
-                : height && height !== 'auto'
-                  ? `${height}px`
-                  : 'auto',
+              height: 'auto',
             }}
             draggable={editor.isEditable}
             className={cn(
@@ -420,12 +373,11 @@ export function ImageView(props: NodeViewProps) {
 
 type ImageStatusLabelProps = {
   status: ImageStatus | 'variable';
-  minHeight?: number | string;
   isDropZone?: boolean;
 } & React.HTMLAttributes<HTMLDivElement>;
 
 export function ImageStatusLabel(props: ImageStatusLabelProps) {
-  const { status, minHeight, className, style, isDropZone, ...rest } = props;
+  const { status, className, style, isDropZone, ...rest } = props;
 
   return (
     <div
@@ -438,14 +390,7 @@ export function ImageStatusLabel(props: ImageStatusLabelProps) {
         },
         className
       )}
-      style={{
-        ...(minHeight
-          ? {
-              minHeight,
-            }
-          : {}),
-        ...style,
-      }}
+      style={style}
     >
       {status === 'idle' && !isDropZone && (
         <>

--- a/packages/core/src/editor/nodes/image/image.ts
+++ b/packages/core/src/editor/nodes/image/image.ts
@@ -23,20 +23,6 @@ export const ImageExtension = TiptapImage.extend({
         },
         renderHTML: ({ width }) => ({ width }),
       },
-      height: {
-        default: 'auto',
-        parseHTML: (element) => {
-          return (
-            element.getAttribute('height') ||
-            (element.style?.height || element.style?.blockSize)?.replace(
-              'px',
-              ''
-            ) ||
-            null
-          );
-        },
-        renderHTML: ({ height }) => ({ height }),
-      },
       alignment: {
         default: 'center',
         renderHTML: ({ alignment }) => ({ 'data-alignment': alignment }),
@@ -108,38 +94,6 @@ export const ImageExtension = TiptapImage.extend({
 
           return {
             'data-is-src-variable': 'true',
-          };
-        },
-      },
-
-      aspectRatio: {
-        default: null,
-        parseHTML: (element) => {
-          return element.getAttribute('data-aspect-ratio') || null;
-        },
-        renderHTML: (attributes) => {
-          if (!attributes?.aspectRatio) {
-            return {};
-          }
-
-          return {
-            'data-aspect-ratio': attributes?.aspectRatio,
-          };
-        },
-      },
-
-      lockAspectRatio: {
-        default: true,
-        parseHTML: (element) => {
-          return element.getAttribute('data-lock-aspect-ratio') === 'true';
-        },
-        renderHTML: (attributes) => {
-          if (!attributes.lockAspectRatio) {
-            return {};
-          }
-
-          return {
-            'data-lock-aspect-ratio': 'true',
           };
         },
       },

--- a/packages/render/src/maily.tsx
+++ b/packages/render/src/maily.tsx
@@ -1148,7 +1148,6 @@ export class Maily {
       alt,
       title,
       width = 'auto',
-      height = 'auto',
       alignment = 'center',
       externalLink = '',
       isExternalLinkVariable,
@@ -1174,17 +1173,13 @@ export class Maily {
     const imageWidth = width === 'auto' ? 'auto' : Number(width);
     const widthStyle = imageWidth === 'auto' ? 'auto' : `${imageWidth}px`;
 
-    // Handle height value
-    const imageHeight = height === 'auto' ? 'auto' : Number(height);
-    const heightStyle = imageHeight === 'auto' ? 'auto' : `${imageHeight}px`;
-
     const mainImage = (
       <Img
         alt={alt || title || 'Image'}
         src={src}
         style={{
           width: widthStyle, // Use the calculated width
-          height: heightStyle, // Use the calculated height
+          height: 'auto', // Let height follow width to preserve aspect ratio
           maxWidth: '100%', // Ensure image doesn't overflow container
           outline: 'none',
           border: 'none',


### PR DESCRIPTION
## Summary
- Fixes [#229](https://github.com/arikchakma/maily.to/issues/229#issuecomment-4632727648) — images render stretched in email clients despite "lock aspect ratio" being on.
- **Why:** the renderer emitted a fixed `height: Npx` on the `<img>` alongside `maxWidth: 100%`. When an email client's column is narrower than the stored width, `maxWidth: 100%` shrinks the rendered width but the fixed height stays put, distorting the image. The "lock aspect ratio" toggle only ever governed the editor, never the output, so it couldn't prevent this.
- **Fix:** the renderer now emits `height: auto` so height follows the (possibly constrained) width and the aspect ratio is always preserved. All existing templates self-heal on next render — no migration needed, since the renderer ignores any stored height.
- Since height is no longer an authored dimension, removed the now-dead machinery in the editor so the canvas matches the output: the `height`, `aspectRatio`, and `lockAspectRatio` attributes, the height input + lock-aspect-ratio toggle in the bubble menu, and the height math in resize/image-load (resize is now width-only; height follows via `auto`, staying proportional during drag).