### PR TITLE
Add backers section to readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -76,10 +76,10 @@ Sponsorship at any level is appreciated and encouraged. If you built a paid prod
 <table align="center" style="justify-content: center;align-items: center;display: flex;">
   <tr>
     <td align="center">
-      <a href="https://github.com/Sendmux">
+      <a href="https://sendmux.ai/?ref=maily.to">
         <img alt="Sendmux" height="40px" width="40px" src="https://github.com/Sendmux.png" style="border-radius: 50%;">
       </a>
-      <p><a href="https://github.com/Sendmux">Sendmux</a></p>
+      <p><a href="https://sendmux.ai/?ref=maily.to">Sendmux</a></p>
     </td>
   </tr>
 </table>

--- a/readme.md
+++ b/readme.md
@@ -71,6 +71,21 @@ Sponsorship at any level is appreciated and encouraged. If you built a paid prod
 
 <br/>
 
+<h4 align="center">Backers</h4>
+
+<table align="center" style="justify-content: center;align-items: center;display: flex;">
+  <tr>
+    <td align="center">
+      <a href="https://github.com/Sendmux">
+        <img alt="Sendmux" height="40px" width="40px" src="https://github.com/Sendmux.png" style="border-radius: 50%;">
+      </a>
+      <p><a href="https://github.com/Sendmux">Sendmux</a></p>
+    </td>
+  </tr>
+</table>
+
+<br/>
+
 ## Contributions
 
 Feel free to submit pull requests, create issues, or spread the word. For getting a development version of it up & running, go through the following steps.


### PR DESCRIPTION
## Summary
- Add a "Backers" section to the readme below the Gold sponsors tier
- List Sendmux as a backer with their GitHub avatar linking to https://github.com/Sendmux
- Sized smaller than the Gold tier (h4 heading, 40px avatar) to reflect the tier hierarchy

## Test plan
- [ ] Preview the readme and confirm the Backers section renders centered below Gold
- [ ] Confirm the Sendmux avatar loads and links to their GitHub profile